### PR TITLE
Reintroduce the Vocab and Storage traits

### DIFF
--- a/rust2vec/src/io.rs
+++ b/rust2vec/src/io.rs
@@ -9,6 +9,7 @@ const MODEL_VERSION: u32 = 0;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum ChunkIdentifier {
+    Header = 0,
     SimpleVocab = 1,
     NdArray = 2,
     SubwordVocab = 3,
@@ -50,6 +51,9 @@ where
 }
 
 pub trait WriteChunk {
+    /// Get the identifier of a chunk.
+    fn chunk_identifier(&self) -> ChunkIdentifier;
+
     fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
     where
         W: Write + Seek;
@@ -90,6 +94,10 @@ impl Header {
 }
 
 impl WriteChunk for Header {
+    fn chunk_identifier(&self) -> ChunkIdentifier {
+        ChunkIdentifier::Header
+    }
+
     fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
     where
         W: Write + Seek,

--- a/rust2vec/src/similarity.rs
+++ b/rust2vec/src/similarity.rs
@@ -6,7 +6,9 @@ use std::collections::{BinaryHeap, HashSet};
 use ndarray::{s, Array1, ArrayView1, ArrayView2};
 use ordered_float::NotNan;
 
+use crate::storage::StorageView;
 use crate::util::l2_normalize;
+use crate::vocab::Vocab;
 use crate::Embeddings;
 
 /// A word with its similarity.
@@ -54,7 +56,11 @@ pub trait Analogy {
     ) -> Option<Vec<WordSimilarity>>;
 }
 
-impl Analogy for Embeddings {
+impl<V, S> Analogy for Embeddings<V, S>
+where
+    V: Vocab,
+    S: StorageView,
+{
     fn analogy(
         &self,
         word1: &str,
@@ -91,7 +97,11 @@ pub trait AnalogyBy {
         F: FnMut(ArrayView2<f32>, ArrayView1<f32>) -> Array1<f32>;
 }
 
-impl AnalogyBy for Embeddings {
+impl<V, S> AnalogyBy for Embeddings<V, S>
+where
+    V: Vocab,
+    S: StorageView,
+{
     fn analogy_by<F>(
         &self,
         word1: &str,
@@ -127,7 +137,11 @@ pub trait Similarity {
     fn similarity(&self, word: &str, limit: usize) -> Option<Vec<WordSimilarity>>;
 }
 
-impl Similarity for Embeddings {
+impl<V, S> Similarity for Embeddings<V, S>
+where
+    V: Vocab,
+    S: StorageView,
+{
     fn similarity(&self, word: &str, limit: usize) -> Option<Vec<WordSimilarity>> {
         self.similarity_by(word, limit, |embeds, embed| embeds.dot(&embed))
     }
@@ -151,7 +165,11 @@ pub trait SimilarityBy {
         F: FnMut(ArrayView2<f32>, ArrayView1<f32>) -> Array1<f32>;
 }
 
-impl SimilarityBy for Embeddings {
+impl<V, S> SimilarityBy for Embeddings<V, S>
+where
+    V: Vocab,
+    S: StorageView,
+{
     fn similarity_by<F>(
         &self,
         word: &str,
@@ -181,7 +199,11 @@ trait SimilarityPrivate {
         F: FnMut(ArrayView2<f32>, ArrayView1<f32>) -> Array1<f32>;
 }
 
-impl SimilarityPrivate for Embeddings {
+impl<V, S> SimilarityPrivate for Embeddings<V, S>
+where
+    V: Vocab,
+    S: StorageView,
+{
     fn similarity_<F>(
         &self,
         embed: ArrayView1<f32>,
@@ -193,7 +215,7 @@ impl SimilarityPrivate for Embeddings {
         F: FnMut(ArrayView2<f32>, ArrayView1<f32>) -> Array1<f32>,
     {
         let sims = similarity(
-            self.data().view().slice(s![0..self.vocab().len(), ..]),
+            self.storage().view().slice(s![0..self.vocab().len(), ..]),
             embed.view(),
         );
 

--- a/rust2vec/src/storage.rs
+++ b/rust2vec/src/storage.rs
@@ -7,7 +7,7 @@ use std::mem;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use failure::{ensure, format_err, Error};
 use memmap::{Mmap, MmapOptions};
-use ndarray::{Array, Array2, ArrayBase, ArrayView, ArrayView2, Data, Dimension, Ix1, Ix2};
+use ndarray::{Array, Array2, ArrayView, ArrayView2, Dimension, Ix1, Ix2};
 use rand::{FromEntropy, Rng};
 use rand_xorshift::XorShiftRng;
 use reductive::pq::{QuantizeVector, ReconstructVector, TrainPQ, PQ};
@@ -47,127 +47,177 @@ where
 /// 1D copy-on-write array.
 pub type CowArray1<'a, A> = CowArray<'a, A, Ix1>;
 
-/// Embedding matrix storage.
-///
-/// To allow for embeddings to be stored in different manners (e.g.
-/// regular *n x d* matrix or as quantized vectors), this trait
-/// abstracts over concrete storage types.
-#[derive(Debug)]
-pub enum Storage {
-    /// In-memory `ndarray` matrix.
-    NdArray(Array2<f32>),
-
-    /// Memory-mapped matrix.
-    Mmap { map: Mmap, shape: Ix2 },
-
-    /// Quantized matrix.
-    Quantized {
-        quantizer: PQ<f32>,
-        quantized: Array2<u8>,
-    },
+/// Memory-mapped matrix.
+pub struct MmapArray {
+    map: Mmap,
+    shape: Ix2,
 }
 
-impl Storage {
-    pub(crate) fn chunk_identifier(&self) -> ChunkIdentifier {
-        match self {
-            Storage::NdArray(_) => ChunkIdentifier::NdArray,
-            Storage::Mmap { .. } => ChunkIdentifier::NdArray,
-            Storage::Quantized { .. } => ChunkIdentifier::QuantizedArray,
-        }
+impl MmapChunk for MmapArray {
+    fn mmap_chunk(read: &mut BufReader<File>) -> Result<Self, Error> {
+        ensure!(
+            read.read_u32::<LittleEndian>()? == ChunkIdentifier::NdArray as u32,
+            "invalid chunk identifier for NdArray"
+        );
+
+        // Read and discard chunk length.
+        read.read_u64::<LittleEndian>()?;
+
+        let rows = read.read_u64::<LittleEndian>()? as usize;
+        let cols = read.read_u32::<LittleEndian>()? as usize;
+        let shape = Ix2(rows, cols);
+
+        ensure!(
+            read.read_u32::<LittleEndian>()? == f32::type_id(),
+            "Expected single precision floating point matrix for NdArray."
+        );
+
+        let n_padding = padding::<f32>(read.seek(SeekFrom::Current(0))?);
+        read.seek(SeekFrom::Current(n_padding as i64))?;
+
+        // Set up memory mapping.
+        let matrix_len = shape.size() * mem::size_of::<f32>();
+        let offset = read.seek(SeekFrom::Current(0))?;
+        let mut mmap_opts = MmapOptions::new();
+        let map = unsafe {
+            mmap_opts
+                .offset(offset)
+                .len(matrix_len)
+                .map(&read.get_ref())?
+        };
+
+        // Position the reader after the matrix.
+        read.seek(SeekFrom::Current(matrix_len as i64))?;
+
+        Ok(MmapArray { map, shape })
+    }
+}
+
+impl WriteChunk for MmapArray {
+    fn chunk_identifier(&self) -> ChunkIdentifier {
+        ChunkIdentifier::NdArray
     }
 
-    pub fn dims(&self) -> usize {
-        match self {
-            Storage::NdArray(ref data) => data.cols(),
-            Storage::Mmap { shape, .. } => shape[1],
-            Storage::Quantized { quantizer, .. } => quantizer.reconstructed_len(),
-        }
-    }
-
-    pub fn embedding(&self, idx: usize) -> CowArray1<f32> {
-        match self {
-            Storage::NdArray { .. } | Storage::Mmap { .. } => {
-                CowArray::Owned(self.view().row(idx).to_owned())
-            }
-            Storage::Quantized {
-                quantizer,
-                quantized,
-            } => CowArray::Owned(quantizer.reconstruct_vector(quantized.row(idx))),
-        }
-    }
-
-    /// Quantize the embedding matrix.
-    ///
-    /// This method trains a quantizer for the embedding matrix and
-    /// then quantizes the matrix using this quantizer.
-    ///
-    /// The xorshift PRNG is used for picking the initial quantizer
-    /// centroids.
-    pub fn quantize<T>(
-        &self,
-        n_subquantizers: usize,
-        n_subquantizer_bits: u32,
-        n_iterations: usize,
-        n_attempts: usize,
-    ) -> Self
+    fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
     where
-        T: TrainPQ<f32>,
+        W: Write + Seek,
     {
-        self.quantize_using::<T, _>(
-            n_subquantizers,
-            n_subquantizer_bits,
-            n_iterations,
-            n_attempts,
-            &mut XorShiftRng::from_entropy(),
-        )
+        NdArray::write_ndarray_chunk(self.view(), write)
     }
+}
 
-    /// Quantize the embedding matrix.
-    ///
-    /// This method trains a quantizer for the embedding matrix and
-    /// then quantizes the matrix using this quantizer.
-    pub fn quantize_using<T, R>(
-        &self,
-        n_subquantizers: usize,
-        n_subquantizer_bits: u32,
-        n_iterations: usize,
-        n_attempts: usize,
-        rng: &mut R,
-    ) -> Self
+/// In-memory `ndarray` matrix.
+#[derive(Debug)]
+pub struct NdArray(pub Array2<f32>);
+
+impl NdArray {
+    fn write_ndarray_chunk<W>(data: ArrayView2<f32>, write: &mut W) -> Result<(), Error>
     where
-        T: TrainPQ<f32>,
-        R: Rng,
+        W: Write + Seek,
     {
-        match self {
-            Storage::NdArray { .. } | Storage::Mmap { .. } => {
-                let quantizer = T::train_pq_using(
-                    n_subquantizers,
-                    n_subquantizer_bits,
-                    n_iterations,
-                    n_attempts,
-                    self.view(),
-                    rng,
-                );
-                let quantized = quantizer.quantize_batch(self.view());
-                Storage::Quantized {
-                    quantizer,
-                    quantized,
-                }
-            }
-            Storage::Quantized {
-                quantizer,
-                quantized,
-            } => Storage::Quantized {
-                quantizer: quantizer.clone(),
-                quantized: quantized.clone(),
-            },
-        }
-    }
+        write.write_u32::<LittleEndian>(ChunkIdentifier::NdArray as u32)?;
+        let n_padding = padding::<f32>(write.seek(SeekFrom::Current(0))?);
+        // Chunk size: rows (8 bytes), columns (4 bytes), type id (4 bytes),
+        //             padding ([0,4) bytes), matrix.
+        let chunk_len =
+            16 + n_padding as usize + (data.rows() * data.cols() * mem::size_of::<f32>());
+        write.write_u64::<LittleEndian>(chunk_len as u64)?;
+        write.write_u64::<LittleEndian>(data.rows() as u64)?;
+        write.write_u32::<LittleEndian>(data.cols() as u32)?;
+        write.write_u32::<LittleEndian>(f32::type_id())?;
 
-    fn read_quantized_array_chunk<R>(read: &mut R) -> Result<Storage, Error>
+        // Write padding, such that the embedding matrix starts on at
+        // a multiple of the size of f32 (4 bytes). This is necessary
+        // for memory mapping a matrix. Interpreting the raw u8 data
+        // as a proper f32 array requires that the data is aligned in
+        // memory. However, we cannot always memory map the starting
+        // offset of the matrix directly, since mmap(2) requires a
+        // file offset that is page-aligned. Since the page size is
+        // always a larger power of 2 (e.g. 2^12), which is divisible
+        // by 4, the offset of the matrix with regards to the page
+        // boundary is also a multiple of 4.
+
+        let padding = vec![0; n_padding as usize];
+        write.write(&padding)?;
+
+        for row in data.outer_iter() {
+            for col in row.iter() {
+                write.write_f32::<LittleEndian>(*col)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ReadChunk for NdArray {
+    fn read_chunk<R>(read: &mut R) -> Result<Self, Error>
     where
         R: Read + Seek,
     {
+        let chunk_id = read.read_u32::<LittleEndian>()?;
+        let chunk_id = ChunkIdentifier::try_from(chunk_id)
+            .ok_or(format_err!("Unknown chunk identifier: {}", chunk_id))?;
+        ensure!(
+            chunk_id == ChunkIdentifier::NdArray,
+            "Cannot read chunk {:?} as NdArray",
+            chunk_id
+        );
+
+        // Read and discard chunk length.
+        read.read_u64::<LittleEndian>()?;
+
+        let rows = read.read_u64::<LittleEndian>()? as usize;
+        let cols = read.read_u32::<LittleEndian>()? as usize;
+
+        ensure!(
+            read.read_u32::<LittleEndian>()? == f32::type_id(),
+            "Expected single precision floating point matrix for NdArray."
+        );
+
+        let n_padding = padding::<f32>(read.seek(SeekFrom::Current(0))?);
+        read.seek(SeekFrom::Current(n_padding as i64))?;
+
+        let mut data = vec![0f32; rows * cols];
+        read.read_f32_into::<LittleEndian>(&mut data)?;
+
+        Ok(NdArray(Array2::from_shape_vec((rows, cols), data)?))
+    }
+}
+
+impl WriteChunk for NdArray {
+    fn chunk_identifier(&self) -> ChunkIdentifier {
+        ChunkIdentifier::NdArray
+    }
+
+    fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
+    where
+        W: Write + Seek,
+    {
+        Self::write_ndarray_chunk(self.0.view(), write)
+    }
+}
+
+/// Quantized matrix.
+pub struct QuantizedArray {
+    quantizer: PQ<f32>,
+    quantized: Array2<u8>,
+}
+
+impl ReadChunk for QuantizedArray {
+    fn read_chunk<R>(read: &mut R) -> Result<Self, Error>
+    where
+        R: Read + Seek,
+    {
+        let chunk_id = read.read_u32::<LittleEndian>()?;
+        let chunk_id = ChunkIdentifier::try_from(chunk_id)
+            .ok_or(format_err!("Unknown chunk identifier: {}", chunk_id))?;
+        ensure!(
+            chunk_id == ChunkIdentifier::QuantizedArray,
+            "Cannot read chunk {:?} as QuantizedArray",
+            chunk_id
+        );
+
         // Read and discard chunk length.
         read.read_u64::<LittleEndian>()?;
 
@@ -218,95 +268,20 @@ impl Storage {
         let quantized =
             Array2::from_shape_vec((n_embeddings, quantized_len), quantized_embeddings_vec)?;
 
-        Ok(Storage::Quantized {
+        Ok(QuantizedArray {
             quantizer: PQ::new(projection, quantizers),
             quantized,
         })
     }
+}
 
-    pub fn read_ndarray_chunk<R>(read: &mut R) -> Result<Storage, Error>
-    where
-        R: Read + Seek,
-    {
-        // Read and discard chunk length.
-        read.read_u64::<LittleEndian>()?;
-
-        let rows = read.read_u64::<LittleEndian>()? as usize;
-        let cols = read.read_u32::<LittleEndian>()? as usize;
-
-        ensure!(
-            read.read_u32::<LittleEndian>()? == f32::type_id(),
-            "Expected single precision floating point matrix for NdArray."
-        );
-
-        let n_padding = padding::<f32>(read.seek(SeekFrom::Current(0))?);
-        read.seek(SeekFrom::Current(n_padding as i64))?;
-
-        let mut data = vec![0f32; rows * cols];
-        read.read_f32_into::<LittleEndian>(&mut data)?;
-
-        Ok(Storage::NdArray(Array2::from_shape_vec(
-            (rows, cols),
-            data,
-        )?))
+impl WriteChunk for QuantizedArray {
+    fn chunk_identifier(&self) -> ChunkIdentifier {
+        ChunkIdentifier::QuantizedArray
     }
 
-    pub fn view(&self) -> ArrayView2<f32> {
-        match self {
-            Storage::NdArray(ref data) => data.view(),
-            Storage::Mmap { map, shape } => unsafe {
-                ArrayView2::from_shape_ptr(*shape, map.as_ptr() as *const f32)
-            },
-            Storage::Quantized { .. } => unimplemented!(),
-        }
-    }
-
-    fn write_ndarray_chunk<S, W>(data: ArrayBase<S, Ix2>, mut write: W) -> Result<(), Error>
+    fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
     where
-        S: Data<Elem = f32>,
-        W: Write + Seek,
-    {
-        write.write_u32::<LittleEndian>(ChunkIdentifier::NdArray as u32)?;
-        let n_padding = padding::<f32>(write.seek(SeekFrom::Current(0))?);
-        // Chunk size: rows (8 bytes), columns (4 bytes), type id (4 bytes),
-        //             padding ([0,4) bytes), matrix.
-        let chunk_len =
-            16 + n_padding as usize + (data.rows() * data.cols() * mem::size_of::<f32>());
-        write.write_u64::<LittleEndian>(chunk_len as u64)?;
-        write.write_u64::<LittleEndian>(data.rows() as u64)?;
-        write.write_u32::<LittleEndian>(data.cols() as u32)?;
-        write.write_u32::<LittleEndian>(f32::type_id())?;
-
-        // Write padding, such that the embedding matrix starts on at
-        // a multiple of the size of f32 (4 bytes). This is necessary
-        // for memory mapping a matrix. Interpreting the raw u8 data
-        // as a proper f32 array requires that the data is aligned in
-        // memory. However, we cannot always memory map the starting
-        // offset of the matrix directly, since mmap(2) requires a
-        // file offset that is page-aligned. Since the page size is
-        // always a larger power of 2 (e.g. 2^12), which is divisible
-        // by 4, the offset of the matrix with regards to the page
-        // boundary is also a multiple of 4.
-
-        let padding = vec![0; n_padding as usize];
-        write.write(&padding)?;
-
-        for row in data.outer_iter() {
-            for col in row.iter() {
-                write.write_f32::<LittleEndian>(*col)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn write_quantized_array_chunk<S, W>(
-        quantizer: &PQ<f32>,
-        quantized: ArrayBase<S, Ix2>,
-        mut write: W,
-    ) -> Result<(), Error>
-    where
-        S: Data<Elem = u8>,
         W: Write + Seek,
     {
         write.write_u32::<LittleEndian>(ChunkIdentifier::QuantizedArray as u32)?;
@@ -317,22 +292,22 @@ impl Storage {
         let n_padding = padding::<f32>(write.seek(SeekFrom::Current(0))?);
         let chunk_size = 32
             + n_padding as usize
-            + quantizer.projection().is_some() as usize
-                * quantizer.reconstructed_len()
-                * quantizer.reconstructed_len()
+            + self.quantizer.projection().is_some() as usize
+                * self.quantizer.reconstructed_len()
+                * self.quantizer.reconstructed_len()
                 * mem::size_of::<f32>()
-            + quantizer.quantized_len()
-                * quantizer.n_quantizer_centroids()
-                * (quantizer.reconstructed_len() / quantizer.quantized_len())
+            + self.quantizer.quantized_len()
+                * self.quantizer.n_quantizer_centroids()
+                * (self.quantizer.reconstructed_len() / self.quantizer.quantized_len())
                 * mem::size_of::<f32>()
-            + quantized.rows() * quantizer.quantized_len();
+            + self.quantized.rows() * self.quantizer.quantized_len();
         write.write_u64::<LittleEndian>(chunk_size as u64)?;
 
-        write.write_u32::<LittleEndian>(quantizer.projection().is_some() as u32)?;
-        write.write_u32::<LittleEndian>(quantizer.quantized_len() as u32)?;
-        write.write_u32::<LittleEndian>(quantizer.reconstructed_len() as u32)?;
-        write.write_u32::<LittleEndian>(quantizer.n_quantizer_centroids() as u32)?;
-        write.write_u64::<LittleEndian>(quantized.rows() as u64)?;
+        write.write_u32::<LittleEndian>(self.quantizer.projection().is_some() as u32)?;
+        write.write_u32::<LittleEndian>(self.quantizer.quantized_len() as u32)?;
+        write.write_u32::<LittleEndian>(self.quantizer.reconstructed_len() as u32)?;
+        write.write_u32::<LittleEndian>(self.quantizer.n_quantizer_centroids() as u32)?;
+        write.write_u64::<LittleEndian>(self.quantized.rows() as u64)?;
 
         // Reconstruction and quantized types.
         write.write_u32::<LittleEndian>(f32::type_id())?;
@@ -342,7 +317,7 @@ impl Storage {
         write.write(&padding)?;
 
         // Write projection matrix.
-        if let Some(projection) = quantizer.projection() {
+        if let Some(projection) = self.quantizer.projection() {
             for row in projection.outer_iter() {
                 for &col in row {
                     write.write_f32::<LittleEndian>(col)?;
@@ -351,7 +326,7 @@ impl Storage {
         }
 
         // Write subquantizers.
-        for subquantizer in quantizer.subquantizers() {
+        for subquantizer in self.quantizer.subquantizers() {
             for row in subquantizer.outer_iter() {
                 for &col in row {
                     write.write_f32::<LittleEndian>(col)?;
@@ -360,7 +335,7 @@ impl Storage {
         }
 
         // Write quantized embedding matrix.
-        for row in quantized.outer_iter() {
+        for row in self.quantized.outer_iter() {
             for &col in row {
                 write.write_u8(col)?;
             }
@@ -370,75 +345,352 @@ impl Storage {
     }
 }
 
-impl MmapChunk for Storage {
-    fn mmap_chunk(read: &mut BufReader<File>) -> Result<Self, Error> {
-        ensure!(
-            read.read_u32::<LittleEndian>()? == ChunkIdentifier::NdArray as u32,
-            "invalid chunk identifier for NdArray"
-        );
+/// Storage types wrapper.
+///
+/// This crate makes it possible to create fine-grained embedding
+/// types, such as `Embeddings<SimpleVocab, NdArray>` or
+/// `Embeddings<SubwordVocab, QuantizedArray>`. However, in some cases
+/// it is more pleasant to have a single type that covers all
+/// vocabulary and storage types. `VocabWrap` and `StorageWrap` wrap
+/// all the vocabularies and storage types known to this crate such
+/// that the type `Embeddings<VocabWrap, StorageWrap>` covers all
+/// variations.
+pub enum StorageWrap {
+    NdArray(NdArray),
+    QuantizedArray(QuantizedArray),
+    MmapArray(MmapArray),
+}
 
-        // Read and discard chunk length.
-        read.read_u64::<LittleEndian>()?;
-
-        let rows = read.read_u64::<LittleEndian>()? as usize;
-        let cols = read.read_u32::<LittleEndian>()? as usize;
-        let shape = Ix2(rows, cols);
-
-        ensure!(
-            read.read_u32::<LittleEndian>()? == f32::type_id(),
-            "Expected single precision floating point matrix for NdArray."
-        );
-
-        let n_padding = padding::<f32>(read.seek(SeekFrom::Current(0))?);
-        read.seek(SeekFrom::Current(n_padding as i64))?;
-
-        // Set up memory mapping.
-        let matrix_len = shape.size() * mem::size_of::<f32>();
-        let offset = read.seek(SeekFrom::Current(0))?;
-        let mut mmap_opts = MmapOptions::new();
-        let map = unsafe {
-            mmap_opts
-                .offset(offset)
-                .len(matrix_len)
-                .map(&read.get_ref())?
-        };
-
-        // Position the reader after the matrix.
-        read.seek(SeekFrom::Current(matrix_len as i64))?;
-
-        Ok(Storage::Mmap { map, shape })
+impl From<MmapArray> for StorageWrap {
+    fn from(s: MmapArray) -> Self {
+        StorageWrap::MmapArray(s)
     }
 }
 
-impl ReadChunk for Storage {
+impl From<NdArray> for StorageWrap {
+    fn from(s: NdArray) -> Self {
+        StorageWrap::NdArray(s)
+    }
+}
+
+impl From<QuantizedArray> for StorageWrap {
+    fn from(s: QuantizedArray) -> Self {
+        StorageWrap::QuantizedArray(s)
+    }
+}
+
+impl ReadChunk for StorageWrap {
     fn read_chunk<R>(read: &mut R) -> Result<Self, Error>
     where
         R: Read + Seek,
     {
+        let chunk_start_pos = read.seek(SeekFrom::Current(0))?;
+
         let chunk_id = read.read_u32::<LittleEndian>()?;
         let chunk_id = ChunkIdentifier::try_from(chunk_id)
             .ok_or(format_err!("Unknown chunk identifier: {}", chunk_id))?;
 
+        read.seek(SeekFrom::Start(chunk_start_pos))?;
+
         match chunk_id {
-            ChunkIdentifier::NdArray => Self::read_ndarray_chunk(read),
-            ChunkIdentifier::QuantizedArray => Self::read_quantized_array_chunk(read),
-            unknown => Err(format_err!("Not a storage chunk: {:?}", unknown)),
+            ChunkIdentifier::NdArray => NdArray::read_chunk(read).map(StorageWrap::NdArray),
+            ChunkIdentifier::QuantizedArray => {
+                QuantizedArray::read_chunk(read).map(StorageWrap::QuantizedArray)
+            }
+            _ => Err(format_err!(
+                "Chunk type {:?} cannot be read as storage",
+                chunk_id
+            )),
         }
     }
 }
 
-impl WriteChunk for Storage {
+impl MmapChunk for StorageWrap {
+    fn mmap_chunk(read: &mut BufReader<File>) -> Result<Self, Error> {
+        let chunk_start_pos = read.seek(SeekFrom::Current(0))?;
+
+        let chunk_id = read.read_u32::<LittleEndian>()?;
+        let chunk_id = ChunkIdentifier::try_from(chunk_id)
+            .ok_or(format_err!("Unknown chunk identifier: {}", chunk_id))?;
+
+        read.seek(SeekFrom::Start(chunk_start_pos))?;
+
+        match chunk_id {
+            ChunkIdentifier::NdArray => MmapArray::mmap_chunk(read).map(StorageWrap::MmapArray),
+            _ => Err(format_err!(
+                "Chunk type {:?} cannot be memory mapped as viewable storage",
+                chunk_id
+            )),
+        }
+    }
+}
+
+impl WriteChunk for StorageWrap {
+    fn chunk_identifier(&self) -> ChunkIdentifier {
+        match self {
+            StorageWrap::MmapArray(inner) => inner.chunk_identifier(),
+            StorageWrap::NdArray(inner) => inner.chunk_identifier(),
+            StorageWrap::QuantizedArray(inner) => inner.chunk_identifier(),
+        }
+    }
+
     fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
     where
         W: Write + Seek,
     {
         match self {
-            Storage::NdArray(ref data) => Self::write_ndarray_chunk(data.view(), write),
-            Storage::Mmap { .. } => Self::write_ndarray_chunk(self.view(), write),
-            Storage::Quantized {
-                quantizer,
-                quantized,
-            } => Self::write_quantized_array_chunk(quantizer, quantized.view(), write),
+            StorageWrap::MmapArray(inner) => inner.write_chunk(write),
+            StorageWrap::NdArray(inner) => inner.write_chunk(write),
+            StorageWrap::QuantizedArray(inner) => inner.write_chunk(write),
+        }
+    }
+}
+
+/// Wrapper for storage types that implement views.
+///
+/// This type covers the subset of storage types that implement
+/// `StorageView`. See the `StorageWrap` type for more information.
+pub enum StorageViewWrap {
+    MmapArray(MmapArray),
+    NdArray(NdArray),
+}
+
+impl From<MmapArray> for StorageViewWrap {
+    fn from(s: MmapArray) -> Self {
+        StorageViewWrap::MmapArray(s)
+    }
+}
+
+impl From<NdArray> for StorageViewWrap {
+    fn from(s: NdArray) -> Self {
+        StorageViewWrap::NdArray(s)
+    }
+}
+
+impl ReadChunk for StorageViewWrap {
+    fn read_chunk<R>(read: &mut R) -> Result<Self, Error>
+    where
+        R: Read + Seek,
+    {
+        let chunk_start_pos = read.seek(SeekFrom::Current(0))?;
+
+        let chunk_id = read.read_u32::<LittleEndian>()?;
+        let chunk_id = ChunkIdentifier::try_from(chunk_id)
+            .ok_or(format_err!("Unknown chunk identifier: {}", chunk_id))?;
+
+        read.seek(SeekFrom::Start(chunk_start_pos))?;
+
+        match chunk_id {
+            ChunkIdentifier::NdArray => NdArray::read_chunk(read).map(StorageViewWrap::NdArray),
+            _ => Err(format_err!(
+                "Chunk type {:?} cannot be read as viewable storage",
+                chunk_id
+            )),
+        }
+    }
+}
+
+impl MmapChunk for StorageViewWrap {
+    fn mmap_chunk(read: &mut BufReader<File>) -> Result<Self, Error> {
+        let chunk_start_pos = read.seek(SeekFrom::Current(0))?;
+
+        let chunk_id = read.read_u32::<LittleEndian>()?;
+        let chunk_id = ChunkIdentifier::try_from(chunk_id)
+            .ok_or(format_err!("Unknown chunk identifier: {}", chunk_id))?;
+
+        read.seek(SeekFrom::Start(chunk_start_pos))?;
+
+        match chunk_id {
+            ChunkIdentifier::NdArray => MmapArray::mmap_chunk(read).map(StorageViewWrap::MmapArray),
+            _ => Err(format_err!(
+                "Chunk type {:?} cannot be memory mapped as viewable storage",
+                chunk_id
+            )),
+        }
+    }
+}
+
+/// Embedding matrix storage.
+///
+/// To allow for embeddings to be stored in different manners (e.g.
+/// regular *n x d* matrix or as quantized vectors), this trait
+/// abstracts over concrete storage types.
+pub trait Storage {
+    fn embedding(&self, idx: usize) -> CowArray1<f32>;
+
+    fn shape(&self) -> (usize, usize);
+}
+
+impl Storage for MmapArray {
+    fn embedding(&self, idx: usize) -> CowArray1<f32> {
+        CowArray::Owned(
+            unsafe { ArrayView2::from_shape_ptr(self.shape, self.map.as_ptr() as *const f32) }
+                .row(idx)
+                .to_owned(),
+        )
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        self.shape.into_pattern()
+    }
+}
+
+impl Storage for NdArray {
+    fn embedding(&self, idx: usize) -> CowArray1<f32> {
+        CowArray::Borrowed(self.0.row(idx))
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        self.0.dim()
+    }
+}
+
+impl Storage for QuantizedArray {
+    fn embedding(&self, idx: usize) -> CowArray1<f32> {
+        CowArray::Owned(self.quantizer.reconstruct_vector(self.quantized.row(idx)))
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        (self.quantized.rows(), self.quantizer.reconstructed_len())
+    }
+}
+
+impl Storage for StorageWrap {
+    fn embedding(&self, idx: usize) -> CowArray1<f32> {
+        match self {
+            StorageWrap::MmapArray(inner) => inner.embedding(idx),
+            StorageWrap::NdArray(inner) => inner.embedding(idx),
+            StorageWrap::QuantizedArray(inner) => inner.embedding(idx),
+        }
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        match self {
+            StorageWrap::MmapArray(inner) => inner.shape(),
+            StorageWrap::NdArray(inner) => inner.shape(),
+            StorageWrap::QuantizedArray(inner) => inner.shape(),
+        }
+    }
+}
+
+impl Storage for StorageViewWrap {
+    fn embedding(&self, idx: usize) -> CowArray1<f32> {
+        match self {
+            StorageViewWrap::MmapArray(inner) => inner.embedding(idx),
+            StorageViewWrap::NdArray(inner) => inner.embedding(idx),
+        }
+    }
+
+    fn shape(&self) -> (usize, usize) {
+        match self {
+            StorageViewWrap::MmapArray(inner) => inner.shape(),
+            StorageViewWrap::NdArray(inner) => inner.shape(),
+        }
+    }
+}
+
+/// Storage that provide a view of the embedding matrix.
+pub trait StorageView: Storage {
+    /// Get a view of the embedding matrix.
+    fn view(&self) -> ArrayView2<f32>;
+}
+
+impl StorageView for NdArray {
+    fn view(&self) -> ArrayView2<f32> {
+        self.0.view()
+    }
+}
+
+impl StorageView for MmapArray {
+    fn view(&self) -> ArrayView2<f32> {
+        unsafe { ArrayView2::from_shape_ptr(self.shape, self.map.as_ptr() as *const f32) }
+    }
+}
+
+impl StorageView for StorageViewWrap {
+    fn view(&self) -> ArrayView2<f32> {
+        match self {
+            StorageViewWrap::MmapArray(inner) => inner.view(),
+            StorageViewWrap::NdArray(inner) => inner.view(),
+        }
+    }
+}
+
+/// Quantizable storage.
+pub trait Quantize {
+    /// Quantize the embedding matrix.
+    ///
+    /// This method trains a quantizer for the embedding matrix and
+    /// then quantizes the matrix using this quantizer.
+    ///
+    /// The xorshift PRNG is used for picking the initial quantizer
+    /// centroids.
+    fn quantize<T>(
+        &self,
+        n_subquantizers: usize,
+        n_subquantizer_bits: u32,
+        n_iterations: usize,
+        n_attempts: usize,
+    ) -> QuantizedArray
+    where
+        T: TrainPQ<f32>,
+    {
+        self.quantize_using::<T, _>(
+            n_subquantizers,
+            n_subquantizer_bits,
+            n_iterations,
+            n_attempts,
+            &mut XorShiftRng::from_entropy(),
+        )
+    }
+
+    fn quantize_using<T, R>(
+        &self,
+        n_subquantizers: usize,
+        n_subquantizer_bits: u32,
+        n_iterations: usize,
+        n_attempts: usize,
+        rng: &mut R,
+    ) -> QuantizedArray
+    where
+        T: TrainPQ<f32>,
+        R: Rng;
+}
+
+impl<S> Quantize for S
+where
+    S: StorageView,
+{
+    /// Quantize the embedding matrix.
+    ///
+    /// This method trains a quantizer for the embedding matrix and
+    /// then quantizes the matrix using this quantizer.
+    fn quantize_using<T, R>(
+        &self,
+        n_subquantizers: usize,
+        n_subquantizer_bits: u32,
+        n_iterations: usize,
+        n_attempts: usize,
+        rng: &mut R,
+    ) -> QuantizedArray
+    where
+        T: TrainPQ<f32>,
+        R: Rng,
+    {
+        let quantizer = T::train_pq_using(
+            n_subquantizers,
+            n_subquantizer_bits,
+            n_iterations,
+            n_attempts,
+            self.view(),
+            rng,
+        );
+
+        let quantized = quantizer.quantize_batch(self.view());
+
+        QuantizedArray {
+            quantizer,
+            quantized,
         }
     }
 }
@@ -453,24 +705,24 @@ mod tests {
     use std::io::{Cursor, Read, Seek, SeekFrom};
 
     use byteorder::{LittleEndian, ReadBytesExt};
-    use ndarray::{Array2, ArrayView2};
+    use ndarray::Array2;
     use reductive::pq::PQ;
 
     use crate::io::{ReadChunk, WriteChunk};
-    use crate::storage::Storage;
+    use crate::storage::{NdArray, Quantize, QuantizedArray, StorageView};
 
     const N_ROWS: usize = 100;
     const N_COLS: usize = 100;
 
-    fn test_ndarray() -> Storage {
+    fn test_ndarray() -> NdArray {
         let test_data = Array2::from_shape_fn((N_ROWS, N_COLS), |(r, c)| {
             r as f32 * N_COLS as f32 + c as f32
         });
 
-        Storage::NdArray(test_data)
+        NdArray(test_data)
     }
 
-    fn test_quantized_array() -> Storage {
+    fn test_quantized_array() -> QuantizedArray {
         let ndarray = test_ndarray();
         ndarray.quantize::<PQ<f32>>(10, 4, 5, 1)
     }
@@ -481,16 +733,6 @@ mod tests {
 
         // Return chunk length.
         read.read_u64::<LittleEndian>().unwrap()
-    }
-
-    fn quantizer_quantized(storage: &Storage) -> Option<(&PQ<f32>, ArrayView2<u8>)> {
-        match storage {
-            Storage::Quantized {
-                quantizer,
-                quantized,
-            } => Some((quantizer, quantized.view())),
-            _ => None,
-        }
     }
 
     #[test]
@@ -513,7 +755,7 @@ mod tests {
         let mut cursor = Cursor::new(Vec::new());
         check_arr.write_chunk(&mut cursor).unwrap();
         cursor.seek(SeekFrom::Start(0)).unwrap();
-        let arr = Storage::read_chunk(&mut cursor).unwrap();
+        let arr = NdArray::read_chunk(&mut cursor).unwrap();
         assert_eq!(arr.view(), check_arr.view());
     }
 
@@ -537,10 +779,8 @@ mod tests {
         let mut cursor = Cursor::new(Vec::new());
         check_arr.write_chunk(&mut cursor).unwrap();
         cursor.seek(SeekFrom::Start(0)).unwrap();
-        let arr = Storage::read_chunk(&mut cursor).unwrap();
-        let (quantizer, quantized) = quantizer_quantized(&arr).unwrap();
-        let (check_quantizer, check_quantized) = quantizer_quantized(&check_arr).unwrap();
-        assert_eq!(quantizer, check_quantizer);
-        assert_eq!(quantized, check_quantized);
+        let arr = QuantizedArray::read_chunk(&mut cursor).unwrap();
+        assert_eq!(arr.quantizer, check_arr.quantizer);
+        assert_eq!(arr.quantized, check_arr.quantized);
     }
 }

--- a/rust2vec/src/tests.rs
+++ b/rust2vec/src/tests.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 
+use crate::vocab::Vocab;
 use crate::word2vec::{ReadWord2Vec, WriteWord2Vec};
 use crate::Embeddings;
 
@@ -10,7 +11,7 @@ fn test_read_word2vec_binary() {
     let mut reader = BufReader::new(f);
     let embeddings = Embeddings::read_word2vec_binary(&mut reader, false).unwrap();
     assert_eq!(41, embeddings.vocab().len());
-    assert_eq!(100, embeddings.embed_len());
+    assert_eq!(100, embeddings.dims());
 }
 
 #[test]

--- a/rust2vec/src/word2vec.rs
+++ b/rust2vec/src/word2vec.rs
@@ -8,9 +8,9 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use failure::{err_msg, Error};
 use ndarray::{Array2, Axis};
 
-use crate::storage::Storage;
+use crate::storage::{NdArray, Storage};
 use crate::util::l2_normalize;
-use crate::vocab::Vocab;
+use crate::vocab::{SimpleVocab, Vocab};
 
 use super::*;
 
@@ -27,7 +27,7 @@ where
     fn read_word2vec_binary(reader: &mut R, normalize: bool) -> Result<Self, Error>;
 }
 
-impl<R> ReadWord2Vec<R> for Embeddings
+impl<R> ReadWord2Vec<R> for Embeddings<SimpleVocab, NdArray>
 where
     R: BufRead,
 {
@@ -60,10 +60,7 @@ where
             }
         }
 
-        Ok(Embeddings::new(
-            Vocab::new_simple_vocab(words),
-            Storage::NdArray(matrix),
-        ))
+        Ok(Embeddings::new(SimpleVocab::new(words), NdArray(matrix)))
     }
 }
 
@@ -98,15 +95,17 @@ where
     fn write_word2vec_binary(&self, w: &mut W) -> Result<(), Error>;
 }
 
-impl<W> WriteWord2Vec<W> for Embeddings
+impl<W, V, S> WriteWord2Vec<W> for Embeddings<V, S>
 where
     W: Write,
+    V: Vocab,
+    S: Storage,
 {
     fn write_word2vec_binary(&self, w: &mut W) -> Result<(), Error>
     where
         W: Write,
     {
-        write!(w, "{} {}\n", self.vocab().len(), self.embed_len())?;
+        write!(w, "{} {}\n", self.vocab().len(), self.dims())?;
 
         for (word, embed) in self.iter() {
             write!(w, "{} ", word)?;


### PR DESCRIPTION
- Reintroduce the Vocab and Storage traits.
- Add the StorageView trait for storage types that can provide a
  matrix view.
- Add the Quantizer trait for storage types that can be quantized.
- Vocabularies and storages are separate types again.
- Add the The VocabWrap and StorageWrap enums . These enums wrap all
  the vocabulary and storage types provided by this crate. This makes
  it possible for crate users to use a single type for all embedding
  variations: Embeddings<VocabWrap, StorageWrap>.
- Add StorageViewWrap as an alternative to StorageWrap for types that
  implement StorageView.

---

Still need a better name for `VocabWrap` and `StorageWrap` though ;). Another glitch are the `into_storage` and `into_storage_view` methods, which are there because we can not make a `From` implementation due to `From<T> for T` in core. Maybe introduce a separate trait for this?