### PR TITLE
Write out chunk lengths more explicitly

### DIFF
--- a/rust2vec/src/word2vec.rs
+++ b/rust2vec/src/word2vec.rs
@@ -21,7 +21,6 @@
 //! let embedding = embeddings.embedding("Berlin");
 //! ```
 
-
 use std::io::{BufRead, Write};
 use std::mem;
 use std::slice::from_raw_parts_mut;


### PR DESCRIPTION
This adds some verbosity, but makes it clearer how the chunk lengths are
computed.