### PR TITLE
Big API cleanup

### DIFF
--- a/rust2vec-utils/src/bin/r2v-convert.rs
+++ b/rust2vec-utils/src/bin/r2v-convert.rs
@@ -3,14 +3,7 @@ use std::io::{BufReader, BufWriter};
 
 use clap::{App, AppSettings, Arg, ArgMatches};
 use failure::err_msg;
-use rust2vec::{
-    io::{MmapEmbeddings, ReadEmbeddings, WriteEmbeddings},
-    storage::StorageWrap,
-    text::{ReadText, ReadTextDims, WriteText, WriteTextDims},
-    vocab::VocabWrap,
-    word2vec::{ReadWord2Vec, WriteWord2Vec},
-    Embeddings,
-};
+use rust2vec::prelude::*;
 use rust2vec_utils::EmbeddingFormat;
 use stdinout::OrExit;
 
@@ -102,11 +95,9 @@ fn read_embeddings(
     match embedding_format {
         Rust2Vec => ReadEmbeddings::read_embeddings(&mut reader),
         Rust2VecMmap => MmapEmbeddings::mmap_embeddings(&mut reader),
-        Word2Vec => {
-            ReadWord2Vec::read_word2vec_binary(&mut reader, true).map(Embeddings::into_storage)
-        }
-        Text => ReadText::read_text(&mut reader, true).map(Embeddings::into_storage),
-        TextDims => ReadTextDims::read_text_dims(&mut reader, true).map(Embeddings::into_storage),
+        Word2Vec => ReadWord2Vec::read_word2vec_binary(&mut reader, true).map(Embeddings::into),
+        Text => ReadText::read_text(&mut reader, true).map(Embeddings::into),
+        TextDims => ReadTextDims::read_text_dims(&mut reader, true).map(Embeddings::into),
     }
     .or_exit("Cannot read embeddings", 1)
 }

--- a/rust2vec-utils/src/bin/r2v-quantize.rs
+++ b/rust2vec-utils/src/bin/r2v-quantize.rs
@@ -8,12 +8,7 @@ use rayon::ThreadPoolBuilder;
 use reductive::pq::PQ;
 #[cfg(feature = "opq")]
 use reductive::pq::{GaussianOPQ, OPQ};
-use rust2vec::{
-    io::WriteEmbeddings,
-    storage::{Quantize, QuantizedArray, Storage, StorageView},
-    vocab::VocabWrap,
-    Embeddings,
-};
+use rust2vec::prelude::*;
 use rust2vec_utils::{read_embeddings_view, EmbeddingFormat};
 use stdinout::OrExit;
 

--- a/rust2vec-utils/src/lib.rs
+++ b/rust2vec-utils/src/lib.rs
@@ -3,15 +3,7 @@ use std::io::BufReader;
 
 use failure::{format_err, Error, ResultExt};
 
-use rust2vec::{
-    io::{MmapEmbeddings, ReadEmbeddings},
-    storage::StorageViewWrap,
-    text::ReadText,
-    text::ReadTextDims,
-    vocab::VocabWrap,
-    word2vec::ReadWord2Vec,
-    Embeddings,
-};
+use rust2vec::prelude::*;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum EmbeddingFormat {
@@ -48,13 +40,9 @@ pub fn read_embeddings_view(
     let embeddings = match embedding_format {
         Rust2Vec => ReadEmbeddings::read_embeddings(&mut reader),
         Rust2VecMmap => MmapEmbeddings::mmap_embeddings(&mut reader),
-        Word2Vec => {
-            ReadWord2Vec::read_word2vec_binary(&mut reader, true).map(Embeddings::into_storage_view)
-        }
-        Text => ReadText::read_text(&mut reader, true).map(Embeddings::into_storage_view),
-        TextDims => {
-            ReadTextDims::read_text_dims(&mut reader, true).map(Embeddings::into_storage_view)
-        }
+        Word2Vec => ReadWord2Vec::read_word2vec_binary(&mut reader, true).map(Embeddings::into),
+        Text => ReadText::read_text(&mut reader, true).map(Embeddings::into),
+        TextDims => ReadTextDims::read_text_dims(&mut reader, true).map(Embeddings::into),
     }
     .context("Cannot read embeddings")?;
 

--- a/rust2vec/src/io.rs
+++ b/rust2vec/src/io.rs
@@ -1,156 +1,29 @@
+//! Traits for I/O.
+//!
+//! This module provides traits for reading embeddings
+//! (`ReadEmbeddings`), memory mapping embeddings (`MmapEmbeddings`),
+//! and writing embeddings (`WriteEmbeddings`).
+
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, Write};
 
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use failure::{ensure, format_err, Error, ResultExt};
+use failure::Error;
 
-const MODEL_VERSION: u32 = 0;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u32)]
-pub enum ChunkIdentifier {
-    Header = 0,
-    SimpleVocab = 1,
-    NdArray = 2,
-    SubwordVocab = 3,
-    QuantizedArray = 4,
-}
-
-impl ChunkIdentifier {
-    pub fn try_from(identifier: u32) -> Option<Self> {
-        use ChunkIdentifier::*;
-
-        match identifier {
-            1 => Some(SimpleVocab),
-            2 => Some(NdArray),
-            3 => Some(SubwordVocab),
-            4 => Some(QuantizedArray),
-            _ => None,
-        }
-    }
-}
-
-pub trait ReadChunk
-where
-    Self: Sized,
-{
-    fn read_chunk<R>(read: &mut R) -> Result<Self, Error>
-    where
-        R: Read + Seek;
-}
-
-/// Memory-mappable chunks.
-pub trait MmapChunk
-where
-    Self: Sized,
-{
-    /// Memory map a chunk.
-    ///
-    /// The given `File` object should be positioned at the start of the chunk.
-    fn mmap_chunk(read: &mut BufReader<File>) -> Result<Self, Error>;
-}
-
-pub trait WriteChunk {
-    /// Get the identifier of a chunk.
-    fn chunk_identifier(&self) -> ChunkIdentifier;
-
-    fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
-    where
-        W: Write + Seek;
-}
-
-pub trait TypeId {
-    fn type_id() -> u32;
-}
-
-macro_rules! typeid_impl {
-    ($type:ty, $id:expr) => {
-        impl TypeId for $type {
-            fn type_id() -> u32 {
-                $id
-            }
-        }
-    };
-}
-
-typeid_impl!(f32, 10);
-typeid_impl!(u8, 1);
-
-#[derive(Debug, Eq, PartialEq)]
-pub struct Header {
-    chunk_identifiers: Vec<ChunkIdentifier>,
-}
-
-impl Header {
-    pub fn new(chunk_identifiers: impl Into<Vec<ChunkIdentifier>>) -> Self {
-        Header {
-            chunk_identifiers: chunk_identifiers.into(),
-        }
-    }
-
-    pub fn chunk_identifiers(&self) -> &[ChunkIdentifier] {
-        &self.chunk_identifiers
-    }
-}
-
-impl WriteChunk for Header {
-    fn chunk_identifier(&self) -> ChunkIdentifier {
-        ChunkIdentifier::Header
-    }
-
-    fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
-    where
-        W: Write + Seek,
-    {
-        write.write_all(&[b'R', b'2', b'V'])?;
-        write.write_u32::<LittleEndian>(MODEL_VERSION)?;
-        write.write_u32::<LittleEndian>(self.chunk_identifiers.len() as u32)?;
-
-        for &identifier in &self.chunk_identifiers {
-            write.write_u32::<LittleEndian>(identifier as u32)?
-        }
-
-        Ok(())
-    }
-}
-
-impl ReadChunk for Header {
-    fn read_chunk<R>(read: &mut R) -> Result<Self, Error>
-    where
-        R: Read + Seek,
-    {
-        // Magic and version ceremony.
-        let mut magic = [0u8; 3];
-        read.read_exact(&mut magic)?;
-        ensure!(
-            magic == [b'R', b'2', b'V'],
-            "File does not have rust2vec magic, expected: R2V, was: {}",
-            String::from_utf8_lossy(&magic)
-        );
-        let version = read.read_u32::<LittleEndian>()?;
-        ensure!(
-            version == MODEL_VERSION,
-            "Unknown model version, expected: {}, was: {}",
-            MODEL_VERSION,
-            version
-        );
-
-        // Read chunk identifiers.
-        let chunk_identifiers_len = read.read_u32::<LittleEndian>()? as usize;
-        let mut chunk_identifiers = Vec::with_capacity(chunk_identifiers_len);
-        for _ in 0..chunk_identifiers_len {
-            let identifier = read
-                .read_u32::<LittleEndian>()
-                .with_context(|e| format!("Cannot read chunk identifier: {}", e))?;
-            let chunk_identifier = ChunkIdentifier::try_from(identifier)
-                .ok_or(format_err!("Unknown chunk identifier: {}", identifier))?;
-            chunk_identifiers.push(chunk_identifier);
-        }
-
-        Ok(Header { chunk_identifiers })
-    }
-}
-
+/// Read rust2vec embeddings.
+///
+/// This trait is used to read embeddings in the rust2vec format.
+/// Implementations are provided for the vocabulary and storage
+/// types in this crate.
+///
+/// ```
+/// use std::fs::File;
+///
+/// use rust2vec::prelude::*;
+///
+/// let mut f = File::open("testdata/similarity.r2v").unwrap();
+/// let embeddings: Embeddings<SimpleVocab, NdArray> =
+///     Embeddings::read_embeddings(&mut f).unwrap();
+/// ```
 pub trait ReadEmbeddings
 where
     Self: Sized,
@@ -160,6 +33,15 @@ where
         R: Read + Seek;
 }
 
+/// Memory-map rust2vec embeddings.
+///
+/// This trait is used to read rust2vec embeddings while [memory
+/// mapping](https://en.wikipedia.org/wiki/Mmap) the embedding matrix.
+/// This leads to considerable memory savings, since the operating
+/// system will load the relevant pages from disk on demand.
+///
+/// Memory mapping is currently not implemented for quantized
+/// matrices.
 pub trait MmapEmbeddings
 where
     Self: Sized,
@@ -167,24 +49,179 @@ where
     fn mmap_embeddings(read: &mut BufReader<File>) -> Result<Self, Error>;
 }
 
+/// Write embeddings in rust2vec format.
+///
+/// This trait is used to write embeddings in rust2vec format. Writing
+/// in rust2vec format is supported regardless of the original format
+/// of the embeddings.
 pub trait WriteEmbeddings {
     fn write_embeddings<W>(&self, write: &mut W) -> Result<(), Error>
     where
         W: Write + Seek;
 }
 
+pub(crate) mod private {
+    use std::fs::File;
+    use std::io::{BufReader, Read, Seek, Write};
+
+    use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+    use failure::{ensure, format_err, Error, ResultExt};
+
+    const MODEL_VERSION: u32 = 0;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[repr(u32)]
+    pub enum ChunkIdentifier {
+        Header = 0,
+        SimpleVocab = 1,
+        NdArray = 2,
+        SubwordVocab = 3,
+        QuantizedArray = 4,
+    }
+
+    impl ChunkIdentifier {
+        pub fn try_from(identifier: u32) -> Option<Self> {
+            use ChunkIdentifier::*;
+
+            match identifier {
+                1 => Some(SimpleVocab),
+                2 => Some(NdArray),
+                3 => Some(SubwordVocab),
+                4 => Some(QuantizedArray),
+                _ => None,
+            }
+        }
+    }
+
+    pub trait TypeId {
+        fn type_id() -> u32;
+    }
+
+    macro_rules! typeid_impl {
+        ($type:ty, $id:expr) => {
+            impl TypeId for $type {
+                fn type_id() -> u32 {
+                    $id
+                }
+            }
+        };
+    }
+
+    typeid_impl!(f32, 10);
+    typeid_impl!(u8, 1);
+
+    pub trait ReadChunk
+    where
+        Self: Sized,
+    {
+        fn read_chunk<R>(read: &mut R) -> Result<Self, Error>
+        where
+            R: Read + Seek;
+    }
+
+    /// Memory-mappable chunks.
+    pub trait MmapChunk
+    where
+        Self: Sized,
+    {
+        /// Memory map a chunk.
+        ///
+        /// The given `File` object should be positioned at the start of the chunk.
+        fn mmap_chunk(read: &mut BufReader<File>) -> Result<Self, Error>;
+    }
+
+    pub trait WriteChunk {
+        /// Get the identifier of a chunk.
+        fn chunk_identifier(&self) -> ChunkIdentifier;
+
+        fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
+        where
+            W: Write + Seek;
+    }
+
+    #[derive(Debug, Eq, PartialEq)]
+    pub(crate) struct Header {
+        chunk_identifiers: Vec<ChunkIdentifier>,
+    }
+
+    impl Header {
+        pub fn new(chunk_identifiers: impl Into<Vec<ChunkIdentifier>>) -> Self {
+            Header {
+                chunk_identifiers: chunk_identifiers.into(),
+            }
+        }
+    }
+
+    impl WriteChunk for Header {
+        fn chunk_identifier(&self) -> ChunkIdentifier {
+            ChunkIdentifier::Header
+        }
+
+        fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
+        where
+            W: Write + Seek,
+        {
+            write.write_all(&[b'R', b'2', b'V'])?;
+            write.write_u32::<LittleEndian>(MODEL_VERSION)?;
+            write.write_u32::<LittleEndian>(self.chunk_identifiers.len() as u32)?;
+
+            for &identifier in &self.chunk_identifiers {
+                write.write_u32::<LittleEndian>(identifier as u32)?
+            }
+
+            Ok(())
+        }
+    }
+
+    impl ReadChunk for Header {
+        fn read_chunk<R>(read: &mut R) -> Result<Self, Error>
+        where
+            R: Read + Seek,
+        {
+            // Magic and version ceremony.
+            let mut magic = [0u8; 3];
+            read.read_exact(&mut magic)?;
+            ensure!(
+                magic == [b'R', b'2', b'V'],
+                "File does not have rust2vec magic, expected: R2V, was: {}",
+                String::from_utf8_lossy(&magic)
+            );
+            let version = read.read_u32::<LittleEndian>()?;
+            ensure!(
+                version == MODEL_VERSION,
+                "Unknown model version, expected: {}, was: {}",
+                MODEL_VERSION,
+                version
+            );
+
+            // Read chunk identifiers.
+            let chunk_identifiers_len = read.read_u32::<LittleEndian>()? as usize;
+            let mut chunk_identifiers = Vec::with_capacity(chunk_identifiers_len);
+            for _ in 0..chunk_identifiers_len {
+                let identifier = read
+                    .read_u32::<LittleEndian>()
+                    .with_context(|e| format!("Cannot read chunk identifier: {}", e))?;
+                let chunk_identifier = ChunkIdentifier::try_from(identifier)
+                    .ok_or(format_err!("Unknown chunk identifier: {}", identifier))?;
+                chunk_identifiers.push(chunk_identifier);
+            }
+
+            Ok(Header { chunk_identifiers })
+        }
+    }
+
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::{Cursor, Seek, SeekFrom};
 
-    use super::{ChunkIdentifier, Header};
-    use crate::io::{ReadChunk, WriteChunk};
+    use crate::io::private::{ChunkIdentifier, Header, ReadChunk, WriteChunk};
 
     #[test]
     fn header_write_read_roundtrip() {
-        let check_header = Header {
-            chunk_identifiers: vec![ChunkIdentifier::SimpleVocab, ChunkIdentifier::NdArray],
-        };
+        let check_header =
+            Header::new(vec![ChunkIdentifier::SimpleVocab, ChunkIdentifier::NdArray]);
         let mut cursor = Cursor::new(Vec::new());
         check_header.write_chunk(&mut cursor).unwrap();
         cursor.seek(SeekFrom::Start(0)).unwrap();

--- a/rust2vec/src/lib.rs
+++ b/rust2vec/src/lib.rs
@@ -4,10 +4,11 @@
 //! embeddings.  rust2vec also provides its own data format that has
 //! various benefits over existing formats.
 
-mod embeddings;
-pub use crate::embeddings::{Embeddings, Iter};
+pub mod embeddings;
 
 pub mod io;
+
+pub mod prelude;
 
 pub mod similarity;
 

--- a/rust2vec/src/prelude.rs
+++ b/rust2vec/src/prelude.rs
@@ -1,0 +1,16 @@
+//! Prelude exports the most commonly-used types and traits.
+
+pub use crate::embeddings::Embeddings;
+
+pub use crate::io::{MmapEmbeddings, ReadEmbeddings, WriteEmbeddings};
+
+pub use crate::storage::{
+    MmapArray, NdArray, Quantize, QuantizedArray, Storage, StorageView, StorageViewWrap,
+    StorageWrap,
+};
+
+pub use crate::text::{ReadText, ReadTextDims, WriteText, WriteTextDims};
+
+pub use crate::word2vec::{ReadWord2Vec, WriteWord2Vec};
+
+pub use crate::vocab::{SimpleVocab, SubwordVocab, Vocab, VocabWrap};

--- a/rust2vec/src/similarity.rs
+++ b/rust2vec/src/similarity.rs
@@ -6,10 +6,10 @@ use std::collections::{BinaryHeap, HashSet};
 use ndarray::{s, Array1, ArrayView1, ArrayView2};
 use ordered_float::NotNan;
 
+use crate::embeddings::Embeddings;
 use crate::storage::StorageView;
 use crate::util::l2_normalize;
 use crate::vocab::Vocab;
-use crate::Embeddings;
 
 /// A word with its similarity.
 ///
@@ -253,9 +253,9 @@ mod tests {
     use std::fs::File;
     use std::io::BufReader;
 
+    use crate::embeddings::Embeddings;
     use crate::similarity::{Analogy, Similarity};
     use crate::word2vec::ReadWord2Vec;
-    use crate::Embeddings;
 
     static SIMILARITY_ORDER_STUTTGART_10: &'static [&'static str] = &[
         "Karlsruhe",

--- a/rust2vec/src/tests.rs
+++ b/rust2vec/src/tests.rs
@@ -1,9 +1,9 @@
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 
+use crate::embeddings::Embeddings;
 use crate::vocab::Vocab;
 use crate::word2vec::{ReadWord2Vec, WriteWord2Vec};
-use crate::Embeddings;
 
 #[test]
 fn test_read_word2vec_binary() {

--- a/rust2vec/src/text.rs
+++ b/rust2vec/src/text.rs
@@ -17,8 +17,7 @@
 //! use std::fs::File;
 //! use std::io::BufReader;
 //!
-//! use rust2vec::Embeddings;
-//! use rust2vec::text::ReadTextDims;
+//! use rust2vec::prelude::*;
 //!
 //! let mut reader = BufReader::new(File::open("testdata/similarity.txt").unwrap());
 //!
@@ -37,11 +36,10 @@ use failure::{ensure, err_msg, Error, ResultExt};
 use itertools::Itertools;
 use ndarray::Array2;
 
+use crate::embeddings::Embeddings;
 use crate::storage::{NdArray, Storage};
 use crate::util::l2_normalize;
 use crate::vocab::{SimpleVocab, Vocab};
-
-use super::*;
 
 /// Method to construct `Embeddings` from a text file.
 ///
@@ -241,10 +239,10 @@ mod tests {
     use std::fs::File;
     use std::io::{BufReader, Read, Seek, SeekFrom};
 
+    use crate::embeddings::Embeddings;
     use crate::storage::{NdArray, StorageView};
     use crate::vocab::{SimpleVocab, Vocab};
     use crate::word2vec::ReadWord2Vec;
-    use crate::Embeddings;
 
     use super::{ReadText, ReadTextDims, WriteText, WriteTextDims};
 

--- a/rust2vec/src/vocab.rs
+++ b/rust2vec/src/vocab.rs
@@ -1,3 +1,5 @@
+//! Embedding vocabularies
+
 use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
@@ -5,7 +7,7 @@ use std::mem::size_of;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use failure::{ensure, err_msg, format_err, Error};
 
-use crate::io::{ChunkIdentifier, ReadChunk, WriteChunk};
+use crate::io::private::{ChunkIdentifier, ReadChunk, WriteChunk};
 use crate::subword::SubwordIndices;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -388,7 +390,7 @@ mod tests {
     use byteorder::{LittleEndian, ReadBytesExt};
 
     use super::{SimpleVocab, SubwordVocab};
-    use crate::io::{ReadChunk, WriteChunk};
+    use crate::io::private::{ReadChunk, WriteChunk};
 
     fn test_simple_vocab() -> SimpleVocab {
         let words = vec![

--- a/rust2vec/src/word2vec.rs
+++ b/rust2vec/src/word2vec.rs
@@ -7,8 +7,7 @@
 //! use std::fs::File;
 //! use std::io::BufReader;
 //!
-//! use rust2vec::Embeddings;
-//! use rust2vec::word2vec::ReadWord2Vec;
+//! use rust2vec::prelude::*;
 //!
 //! let mut reader = BufReader::new(File::open("testdata/similarity.bin").unwrap());
 //!
@@ -29,11 +28,10 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use failure::{err_msg, Error};
 use ndarray::{Array2, Axis};
 
+use crate::embeddings::Embeddings;
 use crate::storage::{NdArray, Storage};
 use crate::util::l2_normalize;
 use crate::vocab::{SimpleVocab, Vocab};
-
-use super::*;
 
 /// Method to construct `Embeddings` from a word2vec binary file.
 ///


### PR DESCRIPTION
- Make {Read,Write,Mmap}Chunk private.
- Embeddings -> embeddings::Embeddings.
- Provide a prelude module that exposes most traits/data structures.
- Remove duplicate WordSimilarity struct.
- Improve documentation coverage.
- Replace into_storage/into_storage_view by specific From
  implementations.