### PR TITLE
Add metadata chunk type

### DIFF
--- a/rust2vec-utils/src/bin/r2v-quantize.rs
+++ b/rust2vec-utils/src/bin/r2v-quantize.rs
@@ -276,7 +276,11 @@ fn main() {
 
     // Quantize
     let quantized_storage = quantize_storage(&config, embeddings.storage());
-    let quantized_embeddings = Embeddings::new(embeddings.vocab().clone(), quantized_storage);
+    let quantized_embeddings = Embeddings::new(
+        embeddings.metadata().cloned(),
+        embeddings.vocab().clone(),
+        quantized_storage,
+    );
 
     write_embeddings(&quantized_embeddings, &config.output_filename);
 

--- a/rust2vec/Cargo.toml
+++ b/rust2vec/Cargo.toml
@@ -25,6 +25,7 @@ ordered-float = "1"
 rand = "0.6"
 rand_xorshift = "0.1"
 reductive = "0.2"
+toml = "0.4"
 
 [dev-dependencies]
 maplit = "1"

--- a/rust2vec/src/embeddings.rs
+++ b/rust2vec/src/embeddings.rs
@@ -3,15 +3,17 @@
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, Write};
 use std::iter::Enumerate;
+use std::mem;
 use std::slice;
 
-use failure::Error;
+use failure::{ensure, Error};
 use ndarray::Array1;
 
 use crate::io::{
-    private::{Header, MmapChunk, ReadChunk, WriteChunk},
+    private::{ChunkIdentifier, Header, MmapChunk, ReadChunk, WriteChunk},
     MmapEmbeddings, ReadEmbeddings, WriteEmbeddings,
 };
+use crate::metadata::Metadata;
 use crate::storage::{
     CowArray, CowArray1, MmapArray, NdArray, QuantizedArray, Storage, StorageViewWrap, StorageWrap,
 };
@@ -25,19 +27,42 @@ use crate::vocab::{SimpleVocab, SubwordVocab, Vocab, VocabWrap, WordIndex};
 /// and analogy queries.
 #[derive(Debug)]
 pub struct Embeddings<V, S> {
+    metadata: Option<Metadata>,
     storage: S,
     vocab: V,
 }
 
 impl<V, S> Embeddings<V, S> {
     /// Construct an embeddings from a vocabulary and storage.
-    pub fn new(vocab: V, storage: S) -> Self {
-        Embeddings { vocab, storage }
+    pub fn new(metadata: Option<Metadata>, vocab: V, storage: S) -> Self {
+        Embeddings {
+            metadata,
+            vocab,
+            storage,
+        }
     }
 
     /// Decompose embeddings in its vocabulary and storage.
-    pub fn into_parts(self) -> (V, S) {
-        (self.vocab, self.storage)
+    pub fn into_parts(self) -> (Option<Metadata>, V, S) {
+        (self.metadata, self.vocab, self.storage)
+    }
+
+    /// Get metadata.
+    pub fn metadata(&self) -> Option<&Metadata> {
+        self.metadata.as_ref()
+    }
+
+    /// Get metadata mutably.
+    pub fn metadata_mut(&mut self) -> Option<&mut Metadata> {
+        self.metadata.as_mut()
+    }
+
+    /// Set metadata.
+    ///
+    /// Returns the previously-stored metadata.
+    pub fn set_metadata(&mut self, mut metadata: Option<Metadata>) -> Option<Metadata> {
+        mem::swap(&mut self.metadata, &mut metadata);
+        metadata
     }
 
     /// Get the embedding storage.
@@ -99,8 +124,8 @@ macro_rules! impl_embeddings_from(
     ($vocab:ty, $storage:ty, $storage_wrap:ty) => {
         impl From<Embeddings<$vocab, $storage>> for Embeddings<VocabWrap, $storage_wrap> {
             fn from(from: Embeddings<$vocab, $storage>) -> Self {
-                let (vocab, storage) = from.into_parts();
-                Embeddings::new(vocab.into(), storage.into())
+                let (metadata, vocab, storage) = from.into_parts();
+                Embeddings::new(metadata, vocab.into(), storage.into())
             }
         }
     }
@@ -139,11 +164,24 @@ where
     S: MmapChunk,
 {
     fn mmap_embeddings(read: &mut BufReader<File>) -> Result<Self, Error> {
-        Header::read_chunk(read)?;
+        let header = Header::read_chunk(read)?;
+        let chunks = header.chunk_identifiers();
+        ensure!(!chunks.is_empty(), "Embedding file without chunks.");
+
+        let metadata = if header.chunk_identifiers()[0] == ChunkIdentifier::Metadata {
+            Some(Metadata::read_chunk(read)?)
+        } else {
+            None
+        };
+
         let vocab = V::read_chunk(read)?;
         let storage = S::mmap_chunk(read)?;
 
-        Ok(Embeddings { vocab, storage })
+        Ok(Embeddings {
+            metadata,
+            vocab,
+            storage,
+        })
     }
 }
 
@@ -156,11 +194,24 @@ where
     where
         R: Read + Seek,
     {
-        Header::read_chunk(read)?;
+        let header = Header::read_chunk(read)?;
+        let chunks = header.chunk_identifiers();
+        ensure!(!chunks.is_empty(), "Embedding file without chunks.");
+
+        let metadata = if header.chunk_identifiers()[0] == ChunkIdentifier::Metadata {
+            Some(Metadata::read_chunk(read)?)
+        } else {
+            None
+        };
+
         let vocab = V::read_chunk(read)?;
         let storage = S::read_chunk(read)?;
 
-        Ok(Embeddings { vocab, storage })
+        Ok(Embeddings {
+            metadata,
+            vocab,
+            storage,
+        })
     }
 }
 
@@ -173,11 +224,21 @@ where
     where
         W: Write + Seek,
     {
-        let header = Header::new(vec![
+        let mut chunks = match self.metadata {
+            Some(ref metadata) => vec![metadata.chunk_identifier()],
+            None => vec![],
+        };
+
+        chunks.extend_from_slice(&[
             self.vocab.chunk_identifier(),
             self.storage.chunk_identifier(),
         ]);
-        header.write_chunk(write)?;
+
+        Header::new(chunks).write_chunk(write)?;
+        if let Some(ref metadata) = self.metadata {
+            metadata.write_chunk(write)?;
+        }
+
         self.vocab.write_chunk(write)?;
         self.storage.write_chunk(write)?;
         Ok(())
@@ -205,8 +266,11 @@ mod tests {
     use std::fs::File;
     use std::io::{BufReader, Cursor, Seek, SeekFrom};
 
+    use toml::{toml, toml_internal};
+
     use super::Embeddings;
     use crate::io::{MmapEmbeddings, ReadEmbeddings, WriteEmbeddings};
+    use crate::metadata::Metadata;
     use crate::storage::{MmapArray, NdArray, StorageView};
     use crate::vocab::SimpleVocab;
     use crate::word2vec::ReadWord2Vec;
@@ -214,6 +278,18 @@ mod tests {
     fn test_embeddings() -> Embeddings<SimpleVocab, NdArray> {
         let mut reader = BufReader::new(File::open("testdata/similarity.bin").unwrap());
         Embeddings::read_word2vec_binary(&mut reader, false).unwrap()
+    }
+
+    fn test_metadata() -> Metadata {
+        Metadata(toml! {
+            [hyperparameters]
+            dims = 300
+            ns = 5
+
+            [description]
+            description = "Test model"
+            language = "de"
+        })
     }
 
     #[test]
@@ -229,6 +305,20 @@ mod tests {
     #[test]
     fn write_read_simple_roundtrip() {
         let check_embeds = test_embeddings();
+        let mut cursor = Cursor::new(Vec::new());
+        check_embeds.write_embeddings(&mut cursor).unwrap();
+        cursor.seek(SeekFrom::Start(0)).unwrap();
+        let embeds: Embeddings<SimpleVocab, NdArray> =
+            Embeddings::read_embeddings(&mut cursor).unwrap();
+        assert_eq!(embeds.storage().view(), check_embeds.storage().view());
+        assert_eq!(embeds.vocab(), check_embeds.vocab());
+    }
+
+    #[test]
+    fn write_read_simple_metadata_roundtrip() {
+        let mut check_embeds = test_embeddings();
+        check_embeds.set_metadata(Some(test_metadata()));
+
         let mut cursor = Cursor::new(Vec::new());
         check_embeds.write_embeddings(&mut cursor).unwrap();
         cursor.seek(SeekFrom::Start(0)).unwrap();

--- a/rust2vec/src/io.rs
+++ b/rust2vec/src/io.rs
@@ -77,6 +77,7 @@ pub(crate) mod private {
         NdArray = 2,
         SubwordVocab = 3,
         QuantizedArray = 4,
+        Metadata = 5,
     }
 
     impl ChunkIdentifier {
@@ -88,6 +89,7 @@ pub(crate) mod private {
                 2 => Some(NdArray),
                 3 => Some(SubwordVocab),
                 4 => Some(QuantizedArray),
+                5 => Some(Metadata),
                 _ => None,
             }
         }
@@ -149,6 +151,10 @@ pub(crate) mod private {
             Header {
                 chunk_identifiers: chunk_identifiers.into(),
             }
+        }
+
+        pub fn chunk_identifiers(&self) -> &[ChunkIdentifier] {
+            &self.chunk_identifiers
         }
     }
 

--- a/rust2vec/src/lib.rs
+++ b/rust2vec/src/lib.rs
@@ -8,6 +8,8 @@ pub mod embeddings;
 
 pub mod io;
 
+pub mod metadata;
+
 pub mod prelude;
 
 pub mod similarity;

--- a/rust2vec/src/metadata.rs
+++ b/rust2vec/src/metadata.rs
@@ -1,0 +1,109 @@
+use std::io::{Read, Seek, Write};
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use failure::{ensure, err_msg, Error};
+use toml::Value;
+
+use crate::io::private::{ChunkIdentifier, ReadChunk, WriteChunk};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Metadata(pub Value);
+
+impl ReadChunk for Metadata {
+    fn read_chunk<R>(read: &mut R) -> Result<Self, Error>
+    where
+        R: Read + Seek,
+    {
+        let chunk_id = ChunkIdentifier::try_from(read.read_u32::<LittleEndian>()?)
+            .ok_or_else(|| err_msg("Unknown chunk identifier"))?;
+        ensure!(
+            chunk_id == ChunkIdentifier::Metadata,
+            "Cannot read chunk {:?} as Metadata",
+            chunk_id
+        );
+
+        // Read chunk length.
+        let chunk_len = read.read_u64::<LittleEndian>()? as usize;
+
+        // Read TOML data.
+        let mut buf = vec![0; chunk_len];
+        read.read_exact(&mut buf)?;
+        let buf_str = String::from_utf8(buf)?;
+
+        Ok(Metadata(buf_str.parse::<Value>()?))
+    }
+}
+
+impl WriteChunk for Metadata {
+    fn chunk_identifier(&self) -> ChunkIdentifier {
+        ChunkIdentifier::Metadata
+    }
+
+    fn write_chunk<W>(&self, write: &mut W) -> Result<(), Error>
+    where
+        W: Write + Seek,
+    {
+        let metadata_str = self.0.to_string();
+
+        write.write_u32::<LittleEndian>(self.chunk_identifier() as u32)?;
+        write.write_u64::<LittleEndian>(metadata_str.len() as u64)?;
+        write.write_all(metadata_str.as_bytes())?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Read, Seek, SeekFrom};
+
+    use byteorder::{LittleEndian, ReadBytesExt};
+    use toml::{toml, toml_internal};
+
+    use super::Metadata;
+    use crate::io::private::{ReadChunk, WriteChunk};
+
+    fn read_chunk_size(read: &mut impl Read) -> u64 {
+        // Skip identifier.
+        read.read_u32::<LittleEndian>().unwrap();
+
+        // Return chunk length.
+        read.read_u64::<LittleEndian>().unwrap()
+    }
+
+    fn test_metadata() -> Metadata {
+        Metadata(toml! {
+            [hyperparameters]
+            dims = 300
+            ns = 5
+
+            [description]
+            description = "Test model"
+            language = "de"
+        })
+    }
+
+    #[test]
+    fn metadata_correct_chunk_size() {
+        let check_metadata = test_metadata();
+        let mut cursor = Cursor::new(Vec::new());
+        check_metadata.write_chunk(&mut cursor).unwrap();
+        cursor.seek(SeekFrom::Start(0)).unwrap();
+
+        let chunk_size = read_chunk_size(&mut cursor);
+        assert_eq!(
+            cursor.read_to_end(&mut Vec::new()).unwrap(),
+            chunk_size as usize
+        );
+    }
+
+    #[test]
+    fn metadata_write_read_roundtrip() {
+        let check_metadata = test_metadata();
+        let mut cursor = Cursor::new(Vec::new());
+        check_metadata.write_chunk(&mut cursor).unwrap();
+        cursor.seek(SeekFrom::Start(0)).unwrap();
+        let metadata = Metadata::read_chunk(&mut cursor).unwrap();
+        assert_eq!(metadata, check_metadata);
+    }
+}

--- a/rust2vec/src/text.rs
+++ b/rust2vec/src/text.rs
@@ -172,7 +172,11 @@ where
         }
     }
 
-    Ok(Embeddings::new(SimpleVocab::new(words), NdArray(matrix)))
+    Ok(Embeddings::new(
+        None,
+        SimpleVocab::new(words),
+        NdArray(matrix),
+    ))
 }
 
 /// Method to write `Embeddings` to a text file.

--- a/rust2vec/src/word2vec.rs
+++ b/rust2vec/src/word2vec.rs
@@ -79,7 +79,11 @@ where
             }
         }
 
-        Ok(Embeddings::new(SimpleVocab::new(words), NdArray(matrix)))
+        Ok(Embeddings::new(
+            None,
+            SimpleVocab::new(words),
+            NdArray(matrix),
+        ))
     }
 }
 


### PR DESCRIPTION
The metadata chunk stores metadata in TOML format. This format was
chosen because it is fairly flexible, but also supported by libraries
in most programming languages.

The new Metadata type wraps the Value type of the toml crate. Using
this type as our representation has two benefits:

1. Data structures that implement serde's Serialize trait can be
   serialized to Value.
2. We can guarantee that the TOML data is valid, which cannot be
   guaranteed for e.g. a String representation without extra
   validation.

Fixes #17.